### PR TITLE
fixes handling multiple arguments in Storage.discovery()

### DIFF
--- a/radicale_storage_decsync/__init__.py
+++ b/radicale_storage_decsync/__init__.py
@@ -157,8 +157,8 @@ class Storage(storage.Storage):
             self.decsync_dir = ""
 
     def discover(self, path, depth="0", child_context_manager=(
-            lambda path, href=None: contextlib.ExitStack())):
-        collections = list(super().discover(path, depth, child_context_manager))
+            lambda path, href=None: contextlib.ExitStack()),user_groups=set()):
+        collections = list(super().discover(path, depth, child_context_manager, user_groups))
         for collection in collections:
             yield collection
 


### PR DESCRIPTION
Seems like radicale added support for groups and is now passing one more argument in `radicale/storage/multifilesystem/discover.py`. I've added missing argument to decsync.storage but nothing else so this does not implement GROUPS/ support.