### PR TITLE
Fix structured data for Radicale 3.6.1

### DIFF
--- a/radicale_storage_decsync/__init__.py
+++ b/radicale_storage_decsync/__init__.py
@@ -179,7 +179,11 @@ class Storage(storage.Storage):
             return
         elif len(attributes) == 1:
             username = attributes[0]
-            known_paths = [collection.path for collection in collections]
+            known_paths = []
+            for collection in collections:
+                if isinstance(collection, tuple):
+                    collection = next((x for x in collection if hasattr(x, "path")), collection[0])
+                known_paths.append(collection.path)
             for sync_type in ["contacts", "calendars", "tasks", "memos"]:
                 for collection in Decsync.list_collections(self.decsync_dir, sync_type):
                     child_path = "/%s/%s-%s/" % (username, sync_type, collection)
@@ -201,7 +205,11 @@ class Storage(storage.Storage):
                             props["C:supported-calendar-component-set"] = "VJOURNAL"
                         else:
                             raise RuntimeError("Unknown sync type " + sync_type)
-                    child = super().create_collection(child_path, props=props)
+                    result = super().create_collection(child_path, props=props)
+                    if isinstance(result, tuple):
+                        child = next((x for x in result if hasattr(x, "decsync")), result[0])
+                    else:
+                        child = result
                     child.decsync.init_stored_entries()
                     child.decsync.execute_stored_entries_for_path_exact(["info"], child)
                     child.decsync.execute_stored_entries_for_path_prefix(["resources"], child)

--- a/radicale_storage_decsync/__init__.py
+++ b/radicale_storage_decsync/__init__.py
@@ -107,6 +107,10 @@ class Collection(storage.Collection, CollectionHrefMappingsMixin):
                     if len(supported) > 1 and item.component_name != "VEVENT":
                         raise RuntimeError("Component not supported by old DecSync.")
                 self.set_href(item.uid, href)
+                # Ensure structured data (lists/tuples) are stringified before serialization
+                for component in item.vobject_item.getChildren():
+                    if isinstance(component.value, (list, tuple)):
+                        component.value = ";".join(str(x) for x in component.value)
                 self.decsync.set_entry(["resources", item.uid], None, item.serialize())
         return result
 

--- a/radicale_storage_decsync/__init__.py
+++ b/radicale_storage_decsync/__init__.py
@@ -94,17 +94,21 @@ class Collection(storage.Collection, CollectionHrefMappingsMixin):
             self.load_hrefs(sync_type)
 
     def upload(self, href, orig_item, update_decsync=True):
-        item = super().upload(href, orig_item)
+        result = super().upload(href, orig_item)
+        if isinstance(result, tuple):
+            item = next((x for x in result if hasattr(x, "uid")), result[1])
+        else:
+            item = result
         if update_decsync:
-            tag = self.get_meta("tag")
-            if tag == "VCALENDAR":
-                supported_components = (self.get_meta("C:supported-calendar-component-set") or "VEVENT,VTODO,VJOURNAL").split(",")
-                component_name = item.component_name
-                if len(supported_components) > 1 and component_name != "VEVENT":
-                    raise RuntimeError("Component " + component_name + " is not supported by old DecSync collections. Create a new collection in Radicale for support.")
-            self.set_href(item.uid, href)
-            self.decsync.set_entry(["resources", item.uid], None, item.serialize())
-        return item
+            if hasattr(self, 'decsync'):
+                tag = self.get_meta("tag")
+                if tag == "VCALENDAR":
+                    supported = (self.get_meta("C:supported-calendar-component-set") or "VEVENT,VTODO,VJOURNAL").split(",")
+                    if len(supported) > 1 and item.component_name != "VEVENT":
+                        raise RuntimeError("Component not supported by old DecSync.")
+                self.set_href(item.uid, href)
+                self.decsync.set_entry(["resources", item.uid], None, item.serialize())
+        return result
 
     def delete(self, href=None, update_decsync=True):
         if update_decsync:
@@ -157,8 +161,8 @@ class Storage(storage.Storage):
             self.decsync_dir = ""
 
     def discover(self, path, depth="0", child_context_manager=(
-            lambda path, href=None: contextlib.ExitStack())):
-        collections = list(super().discover(path, depth, child_context_manager))
+            lambda path, href=None: contextlib.ExitStack()),user_groups=set()):
+        collections = list(super().discover(path, depth, child_context_manager, user_groups))
         for collection in collections:
             yield collection
 
@@ -246,12 +250,16 @@ class Storage(storage.Storage):
             raise RuntimeError("Unknown tag " + tag)
 
         if collection.startswith(sync_type + "-"):
-            path = "/%s/%s/" % (username, collection)
+            path = href 
         else:
             path = "/%s/%s-%s/" % (username, sync_type, collection)
-        col = super().create_collection(path, None, props)
+        result = super().create_collection(path, None, props)
+        if isinstance(result, tuple):
+            col = next((x for x in result if hasattr(x, "get_href")), result[0])
+        else:
+            col = result
         if items is not None:
             for item in items:
                 href = col.get_href(item.uid)
-                col.upload(href, item)
-        return col
+                col.upload(href, item)    
+        return result

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="radicale_storage_decsync",
-    version="2.1.0",
+    version="2.1.0+diagonalarg.1",
     author="Aldo Gunsing",
     author_email="dev@aldogunsing.nl",
     url="https://github.com/39aldo39/Radicale-DecSync",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     packages=["radicale_storage_decsync"],
     install_requires=[
         "radicale>=3",
-        "libdecsync>=2.0.0"
+        "libdecsync @ git+https://github.com/DiagonalArg/libdecsync-bindings-python3.git@fix/remove-pkg-resources"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     packages=["radicale_storage_decsync"],
     install_requires=[
         "radicale>=3",
-        "libdecsync @ git+https://github.com/DiagonalArg/libdecsync-bindings-python3.git@fix/remove-pkg-resources"
+        "libdecsync @ git+https://github.com/DiagonalArg/libdecsync-bindings-python3.git@master"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Provides update to make the plugin compatible with Radicale 3.6.1 and Python 3.12.3, by fixing a data-integrity bug involving structured vCard fields.  Without the added `isinstance` check, contacts with structured fields (eg. addresses or names) cause a TypeError during serialization, halting the sync process.

It has been tested working in:

```
   package radicale 3.6.1, installed using Python 3.12.3
    - radicale
    Injected Packages:
      - radicale_storage_decsync 2.1.0
      - setuptools 79.0.1
```

It is based on [JornJorn](https://github.com/JornJorn/Radicale-DecSync)'s fork, which in turn seems to be based on [mab122](https://github.com/mab122/Radicale-DecSync/tree/fix/storage_discovery_arguments_mismatch)'s.
