### PR TITLE
Fix storage discover signature mismatch

### DIFF
--- a/radicale_storage_decsync/__init__.py
+++ b/radicale_storage_decsync/__init__.py
@@ -157,8 +157,8 @@ class Storage(storage.Storage):
             self.decsync_dir = ""
 
     def discover(self, path, depth="0", child_context_manager=(
-            lambda path, href=None: contextlib.ExitStack())):
-        collections = list(super().discover(path, depth, child_context_manager))
+            lambda path, href=None: contextlib.ExitStack()),user_groups=set()):
+        collections = list(super().discover(path, depth, child_context_manager, user_groups))
         for collection in collections:
             yield collection
 


### PR DESCRIPTION
Use this:

Fix Radicale 3.3 storage discover signature mismatch

This updates `Storage.discover()` in `radicale_storage_decsync` to accept and forward the additional `user_groups` argument expected by newer Radicale versions.

Problem:

* with Radicale 3.3.x, the web/discovery path triggers `PROPFIND /`
* Radicale calls the storage plugin’s `discover()` with an extra argument
* the current plugin signature does not accept it
* result: `Storage.discover() takes from 2 to 4 positional arguments but 5 were given`

Change:

* add `user_groups` to `Storage.discover()`
* pass `user_groups` through to `super().discover(...)`

Why this change:

* fixes the web login/discovery failure on newer Radicale
* preserves existing DecSync write behavior
* avoids unrelated dependency changes

Validation:

* web login to `/.web/` succeeds after this patch
* Evolution calendar save still works after this patch

source:  https://github.com/39aldo39/Radicale-DecSync/pull/34